### PR TITLE
Fixed reuqireAll filter to only include js and json

### DIFF
--- a/source/application/hooks/patterns/index.js
+++ b/source/application/hooks/patterns/index.js
@@ -68,7 +68,7 @@ export default {
 				this.log.silly(`Importing transforms from: ${resolvedTransformPath}`);
 				let resolvedTransformFactories = requireAll({
 					'dirname': resolvedTransformPath,
-					'filter': /^(.*)\.(js|json)/
+					'filter': /^(.*)\.(js|json)$/
 				});
 
 				Object.assign(transformFactories, resolvedTransformFactories);


### PR DESCRIPTION
Only require .js and .json files with requireAll.
