### PR TITLE
FIX #11: Finding the last jsx-expression

### DIFF
--- a/patterns/atoms/fix-for-issue-11/index.jsx
+++ b/patterns/atoms/fix-for-issue-11/index.jsx
@@ -1,0 +1,4 @@
+var someStringWithMarkup = '<span></span>';
+
+<div>
+</div>

--- a/patterns/atoms/fix-for-issue-11/pattern.json
+++ b/patterns/atoms/fix-for-issue-11/pattern.json
@@ -1,0 +1,3 @@
+{
+	"name": "fix-for-issue-11"
+}


### PR DESCRIPTION
The jsx-expression need to be on a separate line only preceeded by
whitespaces.
