### PR TITLE
Make getPatterns fail violently, propagate custom err.file key properly

### DIFF
--- a/source/application/hooks/patterns/index.js
+++ b/source/application/hooks/patterns/index.js
@@ -28,7 +28,7 @@ async function populate(application) {
 		'log': function(...args) {
 			application.log.silly(...['[cache:pattern:getpattern]', ...args]);
 		}
-	}, application.cache, false);
+	}, application.cache);
 
 	let delta = Date.now() - start / 1000;
 

--- a/source/application/hooks/patterns/pattern.js
+++ b/source/application/hooks/patterns/pattern.js
@@ -331,13 +331,13 @@ export class Pattern {
 							let configuration = merge({}, applicationConfig, environmentConfig);
 
 							try {
-								file = await fn(Object.assign({}, file), demo, configuration, forced);
+								file = await fn({...file}, demo, configuration, forced);
 								if (this.cache && this.cache.config.transform && !this.isEnvironment) {
 									this.cache.set(cacheID, mtime, file);
 								}
 							} catch (error) {
 								error.pattern = this.id;
-								error.file = error.file || file.path;
+								error.file = error.file || error.fileName || file.path;
 								error.transform = transform;
 								console.error(`Error while transforming file "${error.file}" of pattern "${error.pattern}" with transform "${error.transform}".`);
 								throw error;

--- a/source/application/routes/pattern.js
+++ b/source/application/routes/pattern.js
@@ -75,7 +75,7 @@ export default function patternRouteFactory (application, configuration) {
 				}
 			};
 
-			patternResults = await getPatterns(patternConfig, application.cache, true);
+			patternResults = await getPatterns(patternConfig, application.cache);
 		} catch (err) {
 			this.throw(500, err);
 		}

--- a/source/application/tasks/build/index.js
+++ b/source/application/tasks/build/index.js
@@ -69,11 +69,10 @@ async function build (application, config) {
 			'config': patternConfig,
 			'factory': application.pattern.factory,
 			'transforms': application.transforms,
-			'filters': {},
 			'log': function(...args) {
 				application.log.debug(...['[console:run]', ...args]);
 			}
-		}, application.cache, false, false);
+		}, application.cache);
 
 		if (application.cache) {
 			application.cache.config.static = true;
@@ -226,11 +225,11 @@ async function build (application, config) {
 				'config': patternConfig,
 				'factory': application.pattern.factory,
 				'transforms': application.transforms,
-				'filters': {},
+				'isEnvironment': true,
 				'log': function(...args) {
 					application.log.debug(...['[console:run]', ...args]);
 				}
-			}, application.cache, false, true);
+			}, application.cache);
 
 			builds.push(pattern[0]);
 		}

--- a/source/application/tasks/commonjs/index.js
+++ b/source/application/tasks/commonjs/index.js
@@ -57,11 +57,10 @@ async function exportAsCommonjs(application, config) {
 			'config': patternConfig,
 			'factory': application.pattern.factory,
 			'transforms': application.transforms,
-			'filters': {},
 			'log': function(...args) {
 				application.log.debug(...['[console:run]', ...args]);
 			}
-		}, application.cache, false, false);
+		}, application.cache);
 
 		if (application.cache) {
 			application.cache.config.static = true;
@@ -164,11 +163,11 @@ async function exportAsCommonjs(application, config) {
 				'config': patternConfig,
 				'factory': application.pattern.factory,
 				'transforms': application.transforms,
-				'filters': {},
+				'isEnvironment': true,
 				'log': function(...args) {
 					application.log.debug(...['[console:run]', ...args]);
 				}
-			}, application.cache, false, true);
+			}, application.cache);
 
 			builds.push(pattern[0]);
 		}

--- a/source/application/transforms/browserify/index.js
+++ b/source/application/transforms/browserify/index.js
@@ -17,9 +17,7 @@ async function runBundler (bundler, config, meta) {
 	return new Promise(function bundlerResolver (resolver, rejecter) {
 		bundler.bundle(function onBundle (err, buffer) {
 			if (err) {
-				console.error('Error while bundling ' + meta.path);
-				console.error(err);
-				rejecter(err);
+				return rejecter(err);
 			}
 
 			resolver({
@@ -63,6 +61,7 @@ async function resolveDependencies (file, configuration) {
 		if (dependency.dependencies && Object.keys(dependency.dependencies).length > 0) {
 			let basedir = dirname(dependency.path);
 			let opts = {expose, basedir};
+
 			let dependencyBundler = resolveDependencies(dependency, Object.assign(
 				{}, configuration.opts, opts,
 				{ 'standalone': expose }
@@ -71,7 +70,7 @@ async function resolveDependencies (file, configuration) {
 			try {
 				transformed = await runBundler(dependencyBundler, configuration, dependency);
 			} catch (err) {
-				throw (err);
+				throw err;
 			}
 
 			dependency.buffer = transformed.buffer.toString('utf-8');

--- a/source/application/transforms/less/index.js
+++ b/source/application/transforms/less/index.js
@@ -6,11 +6,7 @@ import PatternImporterPlugin from 'less-plugin-pattern-import';
 import NPMImporterPlugin from 'less-plugin-npm-import';
 
 async function render (source, config) {
-	try {
-		return await less.render(source, config);
-	} catch (lessError) {
-		throw lessError;
-	}
+	return await less.render(source, config);
 }
 
 export default function lessTransformFactory (application) {
@@ -57,24 +53,15 @@ export default function lessTransformFactory (application) {
 			source = `${injects.join('\n')}\n${source}`;
 		}
 
-		try {
-			results = await render(source, config.opts);
-		} catch (err) {
-			throw err;
-		}
+		results = await render(source, config.opts);
 
 		if (demo) {
 			let demoSource = demo.buffer.toString('utf-8');
 			let demoConfig = Object.assign({}, configuration);
 			let demoDepdendencies = Object.assign({}, dependencies, {'Pattern': file.path});
 
-			try {
-				demoConfig.opts.plugins.push(new PatternImporterPlugin({'root': patternPath, 'patterns': demoDepdendencies}));
-				demoResults = await render(demoSource, demoConfig.opts);
-			} catch (err) {
-				err.file = demo.path;
-				throw err;
-			}
+			demoConfig.opts.plugins.push(new PatternImporterPlugin({'root': patternPath, 'patterns': demoDepdendencies}));
+			demoResults = await render(demoSource, demoConfig.opts);
 
 			file.demoBuffer = new Buffer(demoResults.css || '', 'utf-8');
 			file.demoSource = demo.source;


### PR DESCRIPTION
This
- Remove the fail flag from `getPatterns`
- Moves the `isEnvironment` into `options` for `getPatterns(<options>, <cache>)`
- Makes `getPatterns` failing loudly when there are errors during Pattern::read or Pattern::transform
- Improves the Propagation of the `file` key on `Errors` thrown by all transforms
