### PR TITLE
Include Support for Browserify external bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     {
       "name": "Markus Wolf",
       "email": "markus.wolf@sinnerschrader.com"
+    },
+    {
+      "name": "Mauricio Palma",
+      "email": "mauricio.palma@sinnerschrader.com"
     }
   ],
   "license": "MIT",

--- a/source/application/transforms/browserify/index.js
+++ b/source/application/transforms/browserify/index.js
@@ -117,10 +117,7 @@ function browserifyTransformFactory (application) {
 
 		const bundlerConfigNames = ['external', 'exclude', 'ignore'];
 		const applyBundlerConfig = (bundler, method, config) => {
-			if (config[0] === undefined) {
-				return;
-			}
-			config.map(file => {
+			config.forEach(file => {
 				bundler[method](file);
 			});
 			return bundler;

--- a/source/application/transforms/browserify/index.js
+++ b/source/application/transforms/browserify/index.js
@@ -115,15 +115,15 @@ function browserifyTransformFactory (application) {
 			return results;
 		}, {});
 
-		const externalBundles = configuration.external;
-		const externalBundlesNames = (bundles, fn) => {
-				if (bundles[0] === undefined ) {
-					return;
-				}
-				bundles.map(bundleName => {
-					fn.external(bundleName);
-				});
-				return bundles;
+		const bundlerConfigNames = ['external', 'exclude', 'ignore'];
+		const applyBundlerConfig = (bundler, method, config) => {
+			if (config[0] === undefined) {
+				return;
+			}
+			config.map(file => {
+				bundler[method](file);
+			});
+			return bundler;
 		};
 
 		if (!demo) {
@@ -145,7 +145,9 @@ function browserifyTransformFactory (application) {
 				}
 			}
 
-			let external = externalBundlesNames(externalBundles, bundler);
+			let bundlerConfig = bundlerConfigNames.forEach(bundleOpt => {
+				applyBundlerConfig(bundler, bundleOpt, configuration[bundleOpt]);
+			});
 			let mtime = getLatestMTime(file);
 			let transformed = application.cache && application.cache.get(`browserify:${file.path}`, mtime);
 

--- a/source/application/transforms/browserify/index.js
+++ b/source/application/transforms/browserify/index.js
@@ -115,6 +115,17 @@ function browserifyTransformFactory (application) {
 			return results;
 		}, {});
 
+		const externalBundles = configuration.external;
+		const externalBundlesNames = (bundles, fn) => {
+				if (bundles[0] === undefined ) {
+					return;
+				}
+				bundles.map(bundleName => {
+					fn.external(bundleName);
+				});
+				return bundles;
+		};
+
 		if (!demo) {
 			let bundler;
 
@@ -134,6 +145,7 @@ function browserifyTransformFactory (application) {
 				}
 			}
 
+			let external = externalBundlesNames(externalBundles, bundler);
 			let mtime = getLatestMTime(file);
 			let transformed = application.cache && application.cache.get(`browserify:${file.path}`, mtime);
 

--- a/source/configuration/transforms.js
+++ b/source/configuration/transforms.js
@@ -51,7 +51,9 @@ export default {
 				}
 			}
 		},
-		'external': []
+		'external': [],
+		'exclude': [],
+		'ignore': []
 	},
 	'uglify': {
 		'inFormat': 'js',

--- a/source/configuration/transforms.js
+++ b/source/configuration/transforms.js
@@ -50,7 +50,8 @@ export default {
 					'global': true
 				}
 			}
-		}
+		},
+		'external': []
 	},
 	'uglify': {
 		'inFormat': 'js',


### PR DESCRIPTION
Add external bundles support to the browserify transform. Appreciate constructive feedback to improve the feature.
