### PR TITLE
fix(application/hooks/transforms): Fixes es6 compatible exports

### DIFF
--- a/source/application/hooks/transforms/index.js
+++ b/source/application/hooks/transforms/index.js
@@ -105,7 +105,7 @@ export default {
 				const [name, factory] = entry;
 				return {
 					...registry,
-					[name]: factory(application)
+					[name]: (factory.default ? factory.default : factory)(application)
 				};
 			}, {});
 


### PR DESCRIPTION
This fixes transform factory functions which are exported as es6 default.
