### PR TITLE
correct patterns to build detection for windows

### DIFF
--- a/source/application/tasks/build-commonjs/index.js
+++ b/source/application/tasks/build-commonjs/index.js
@@ -129,11 +129,6 @@ async function exportAsCommonjs(application, settings) {
 		application.log.info(wait`Building ${patternsToBuild.length} of ${patternMtimes.length} patterns`);
 	}
 
-
-	if (!hasManifest) {
-		application.log.info(ok`Target folder has no manifest file, building all patterns`);
-	}
-
 	// build patterns in parallel
 	const buildStart = new Date();
 	const building = Promise.all(patternsToBuild.map(throat(5, async pattern => {

--- a/source/application/tasks/build-commonjs/index.js
+++ b/source/application/tasks/build-commonjs/index.js
@@ -115,14 +115,20 @@ async function exportAsCommonjs(application, settings) {
 	// obtain patterns we have to build
 	const selectionStart = new Date();
 	application.log.info(wait`Calculating pattern collection to build`);
+
 	const patternsToBuild = hasManifest ?
 		patternMtimes
 			.filter(getPatternsToBuild(artifactMtimes, application.configuration.patterns))
 			.sort((a, b) => b.mtime.getTime() - a.mtime.getTime()) :
 		patternMtimes;
 
-	application.log.info(ok`Calculated pattern collection to build ${selectionStart}`);
-	application.log.info(wait`Building ${patternsToBuild.length} of ${patternMtimes.length} patterns`);
+	if (!hasManifest) {
+		application.log.info(ok`No manifest at ${commonjsRoot}, building all ${patternMtimes.length} patterns`);
+	} else {
+		application.log.info(ok`Calculated pattern collection to build ${selectionStart}`);
+		application.log.info(wait`Building ${patternsToBuild.length} of ${patternMtimes.length} patterns`);
+	}
+
 
 	if (!hasManifest) {
 		application.log.info(ok`Target folder has no manifest file, building all patterns`);

--- a/source/library/utilities/get-artifact-mtimes.js
+++ b/source/library/utilities/get-artifact-mtimes.js
@@ -23,6 +23,7 @@ const stat = denodeify(statNodeback);
 
 export default async function getArtifactMtimes(search, patterns) {
 	const debug = debuglog('artifact-mtimes');
+	const distributionDirectory = resolve(search, 'distribution');
 
 	const types = Object.keys(patterns.formats)
 		.map(extension => patterns.formats[extension].name);
@@ -37,8 +38,9 @@ export default async function getArtifactMtimes(search, patterns) {
 
 	const artifactMtimes = await Promise.all(artifactPaths
 		.map(throat(1, async path => {
-			const artifactId = dirname(relative(resolve(search, 'distribution'), path).split(sep).join('/'));
-			const patternId = artifactId.split(sep).slice(1).join('/');
+			const relativeArtifactPath = relative(distributionDirectory, path);
+			const artifactId = dirname(relativeArtifactPath.split(sep).join('/'));
+			const patternId = artifactId.split('/').slice(1).join('/');
 			const stats = await stat(path);
 
 			return {

--- a/source/library/utilities/get-artifact-mtimes.js
+++ b/source/library/utilities/get-artifact-mtimes.js
@@ -10,6 +10,8 @@ import {
 	sep
 } from 'path';
 
+import throat from 'throat';
+
 import {
 	debuglog
 } from 'util';
@@ -34,7 +36,7 @@ export default async function getArtifactMtimes(search, patterns) {
 		.reduce((flattened, files) => [...flattened, ...files], []);
 
 	const artifactMtimes = await Promise.all(artifactPaths
-		.map(async path => {
+		.map(throat(1, async path => {
 			const artifactId = dirname(relative(resolve(search, 'distribution'), path).split(sep).join('/'));
 			const patternId = artifactId.split(sep).slice(1).join('/');
 			const stats = await stat(path);
@@ -45,7 +47,7 @@ export default async function getArtifactMtimes(search, patterns) {
 				patternId,
 				mtime: stats.mtime
 			};
-		}));
+		})));
 
 	const artifactRegistry = artifactMtimes.reduce((registry, artifact) => {
 		const item = registry[artifact.patternId] || {

--- a/source/library/utilities/get-patterns-to-build.js
+++ b/source/library/utilities/get-patterns-to-build.js
@@ -55,4 +55,3 @@ export default function getPatternsToBuild(artifacts, patterns) {
 		}
 	};
 }
-


### PR DESCRIPTION
These changes 
-  limit concurrency when reading mtimes from pattern sources and artifact files
-  fix a bug where `path.sep` was used for id splitting instead of plain `/`
-  limit type detection on pattern sources to files where `path.parse(filePath).name === 'index'`
