### PR TITLE
feat: pass through web formats

### DIFF
--- a/source/library/get-pattern-demo.js
+++ b/source/library/get-pattern-demo.js
@@ -18,15 +18,11 @@ async function getPatternDemo(application, id, filters, environment) {
 
 	const order = ['demo', 'index'];
 
-	const path = Object.values(pattern.files)
+	const file = Object.values(pattern.files)
 		.sort((a, b) => order.indexOf(a.basename) - order.indexOf(b.basename))
-		.map(file => file.path)[0];
+		.find(file => file.format === 'html');
 
-	if (!path) {
-		return null;
-	}
-
-	const content = await getFile(path, 'transformed', environment);
+	const content = file ? await getFile(file.path, 'transformed', environment) : {body: ''};
 
 	const {formats} = application.configuration.patterns;
 	const automount = selectAutoMount(application, pattern);
@@ -93,6 +89,12 @@ function getUriByFormat(pattern, format = '') {
 		return `./index.${match.extension}`;
 	}
 
+	const extensionMatch = outFormats.find(o => o.extension === type);
+
+	if (extensionMatch) {
+		return `./index.${extensionMatch.extension}`;
+	}
+
 	return null;
 }
 
@@ -116,7 +118,8 @@ function getFormat(formats, transforms, type) {
 		return (legacy[0] || {}).name || legacy[0];
 	}
 
-	return null;
+	// fall back to formatName
+	return formatName;
 }
 
 function findByName(name) {

--- a/source/library/get-pattern-meta-data.js
+++ b/source/library/get-pattern-meta-data.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import {omit, uniqBy} from 'lodash';
+import {isEmpty, omit, uniqBy} from 'lodash';
 import getPatternData from './get-pattern-data';
 
 export default getPatternMetaData;
@@ -30,12 +30,15 @@ async function getPatternMetaData(application, id, env = 'index') {
 	};
 }
 
+const defaultFormats = {js: {name: 'js'}, css: {name: 'css'}, html: {name: 'html'}};
+
 function selectPatternFiles(data, config) {
 	const {files} = data;
 	return data.outFormats.reduce((registry, outFormat) => {
 		const {name, type} = outFormat;
+		const formats = isEmpty(config.formats) ? defaultFormats : config.formats;
 
-		const candidates = Object.entries(config.formats)
+		const candidates = Object.entries(formats)
 			.filter(entry => entry[1].name === outFormat.name)
 			.map(entry => entry[0]);
 

--- a/source/library/pattern/pattern/get-transform.js
+++ b/source/library/pattern/pattern/get-transform.js
@@ -3,15 +3,21 @@ import applyTransforms from './apply-transforms';
 
 export default getTransform;
 
+const passthroughFormats = ['html', 'css', 'js', 'md'];
+
 function getTransform(transformFunctions, config) {
 	return async file => {
-		const {patterns, log, transformConfigs} = config;
+		const {patterns, transformConfigs} = config;
 		const format = patterns.formats[file.format];
+		const formatConfigured = isObject(format);
+		const isPassThroughFormat = passthroughFormats.includes(file.format);
 
-		if (!isObject(format)) {
-			const formatNames = Object.keys(patterns.formats);
-			log.debug(`${file.path} has no configured format. Available: ${formatNames}`);
-			return null;
+		if (!formatConfigured && isPassThroughFormat) {
+			return Promise.resolve([file]);
+		}
+
+		if (!formatConfigured) {
+			return Promise.resolve([]);
 		}
 
 		file.meta.devDependencies = getDevDependencies(file, format);

--- a/source/library/pattern/pattern/read.js
+++ b/source/library/pattern/pattern/read.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import chalk from 'chalk';
-import {uniq} from 'lodash';
+import {isEmpty, uniq} from 'lodash';
 import mzFs from 'mz/fs';
 import throat from 'throat';
 import constructFileDependencies from './construct-file-dependencies';
@@ -21,7 +21,9 @@ async function read(pattern, subPath) {
 	// use filter, use all formats if none given
 	const inFormats = pattern.filters.inFormats.length > 0 ?
 		pattern.filters.inFormats :
-		uniq(Object.keys(pattern.config.patterns.formats));
+		isEmpty(pattern.config.patterns.formats) ?
+			['html', 'js', 'css', 'md'] :
+			uniq(Object.keys(pattern.config.patterns.formats));
 
 	const filterOutFormats = pattern.filters.outFormats.length ?
 		outFormat => pattern.filters.outFormats.includes(outFormat) :
@@ -96,7 +98,7 @@ async function read(pattern, subPath) {
 		.map(file => {
 			const inFileFormat = path.extname(file).slice(1);
 			const formatConfig = pattern.config.patterns.formats[inFileFormat] || {};
-			const name = formatConfig.name || '';
+			const name = formatConfig.name || inFileFormat;
 			const transformNames = formatConfig.transforms || [];
 			const lastTransform = pattern.config.transforms[transformNames[transformNames.length - 1]] || {};
 


### PR DESCRIPTION
Work in progress.

This is a prototype for the changes required to enable pass through of web-related formats when no `patterns.formats` configuration is given

compare sinnerschrader/patternplate#115