### PR TITLE
feat: make commonjs build path configurable

### DIFF
--- a/source/application/tasks/build-commonjs/index.js
+++ b/source/application/tasks/build-commonjs/index.js
@@ -58,7 +58,7 @@ async function exportAsCommonjs(application, settings) {
 	const cwd = application.runtime.patterncwd || application.runtime.cwd;
 
 	const patternRoot = resolve(cwd, 'patterns');
-	const commonjsRoot = resolve(cwd, 'build', 'build-commonjs');
+	const commonjsRoot = resolve(cwd, settings.out || join('build', 'build-commonjs'));
 	const manifestPath = resolve(commonjsRoot, 'package.json');
 	const filters = {...settings.filters || {}, baseNames: ['index']};
 


### PR DESCRIPTION
added "out" property to build-commonjs task configuration to define output directory relative to cwd, e.g.

```js
// configuration/patternplate-server/tasks.js
module.exports = {
  'build-commonjs': {
    out: './build/path',
    // ...
  }
};
```